### PR TITLE
Fix mobile route limit parsing

### DIFF
--- a/server/mobile-routes.ts
+++ b/server/mobile-routes.ts
@@ -208,7 +208,7 @@ export function setupMobileRoutes(app: Express) {
       }
       
       if (limit) {
-        jobOrders = jobOrders.slice(0, parseInt(limit as string));
+        jobOrders = jobOrders.slice(0, parseInt(limit as string, 10));
       }
       
       res.json(jobOrders);
@@ -232,7 +232,7 @@ export function setupMobileRoutes(app: Express) {
       });
       
       if (limit) {
-        qualityChecks = qualityChecks.slice(0, parseInt(limit as string));
+        qualityChecks = qualityChecks.slice(0, parseInt(limit as string, 10));
       }
       
       res.json(qualityChecks);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,5 @@
       "@shared/*": ["./shared/*"]
     }
   },
-  "include": ["client/src", "server", "shared"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["client/src", "server", "shared"]
 }


### PR DESCRIPTION
## Summary
- fix `parseInt` usage in mobile job order and quality check APIs
- clean up tsconfig project references to avoid unnecessary errors

## Testing
- `npm run check` *(fails: Type 'boolean' is not assignable to type 'never')*

------
https://chatgpt.com/codex/tasks/task_e_685879afe8888324bcb223a50476a831